### PR TITLE
Pomodoro-Timer-CLI added

### DIFF
--- a/Pomodoro-Timer-CLI/README.md
+++ b/Pomodoro-Timer-CLI/README.md
@@ -1,0 +1,43 @@
+# Pomodoro-Timer-CLI
+
+A lightweight, dependency-free command-line Pomodoro timer.
+
+## Features
+- **Configurable durations** for focus, short break, and long break
+- **Configurable cycles**
+- **Cross-platform** (Windows/macOS/Linux) with optional sound beeps
+- **No external packages** required
+
+## Usage
+Run with Python 3:
+
+```bash
+python pomodoro.py --work 25 --short 5 --long 15 --cycles 4
+```
+
+### Options
+- `--work <minutes>`: Focus duration (default 25)
+- `--short <minutes>`: Short break duration (default 5)
+- `--long <minutes>`: Long break duration (default 15)
+- `--cycles <n>`: Number of focus cycles (default 4)
+- `--no-sound`: Disable sound notifications
+
+### Examples
+- Classic Pomodoro (25/5 with 15-minute long break, 4 cycles):
+  ```bash
+  python pomodoro.py
+  ```
+- Quick test run:
+  ```bash
+  python pomodoro.py --work 1 --short 1 --long 2 --cycles 2
+  ```
+
+## Notes
+- On Windows, the app uses `winsound.Beep` when available; otherwise it falls back to a terminal bell.
+- Press `Ctrl+C` to stop at any time.
+
+## Contributing
+This project is intended for Hacktoberfest. Feel free to open issues or PRs for enhancements such as:
+- Pausing/resuming
+- Custom sound themes
+- Saving session stats

--- a/Pomodoro-Timer-CLI/pomodoro.py
+++ b/Pomodoro-Timer-CLI/pomodoro.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Pomodoro Timer CLI
+
+A simple command-line Pomodoro timer with configurable durations and cycles.
+Works on Windows, macOS, and Linux without external dependencies.
+"""
+
+import argparse
+import sys
+import time
+
+
+def fmt_time(seconds: int) -> str:
+    minutes, secs = divmod(int(seconds), 60)
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def beep(enabled: bool = True, times: int = 1) -> None:
+    if not enabled:
+        return
+    try:
+        # winsound is available on Windows
+        import winsound  # type: ignore
+
+        for _ in range(times):
+            winsound.Beep(1000, 200)
+            time.sleep(0.05)
+    except Exception:
+        # Fallback to terminal bell
+        for _ in range(times):
+            print("\a", end="", flush=True)
+            time.sleep(0.1)
+
+
+def countdown(total_seconds: int, label: str, sound: bool) -> None:
+    start = time.time()
+    end = start + total_seconds
+    try:
+        while True:
+            remaining = max(0, int(end - time.time()))
+            # Draw a single-line updating timer
+            sys.stdout.write(f"\r{label:<14} | {fmt_time(remaining)}    ")
+            sys.stdout.flush()
+            if remaining <= 0:
+                break
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        print("\nInterrupted. Exiting...")
+        raise
+    finally:
+        print()  # move to next line
+    beep(sound, times=2)
+
+
+def run_pomodoro(work: int, short: int, long: int, cycles: int, sound: bool) -> None:
+    if work <= 0 or short <= 0 or long <= 0 or cycles <= 0:
+        raise ValueError("All durations and cycle count must be positive integers.")
+
+    try:
+        for c in range(1, cycles + 1):
+            print(f"\nCycle {c}/{cycles}")
+            countdown(work * 60, "Focus", sound)
+            if c < cycles:
+                countdown(short * 60, "Short break", sound)
+            else:
+                countdown(long * 60, "Long break", sound)
+        print("All cycles complete. Great job!")
+        beep(sound, times=3)
+    except KeyboardInterrupt:
+        # Graceful shutdown already printed in countdown
+        pass
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run a Pomodoro timer with configurable durations and cycles.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--work", type=int, default=25, help="Focus duration in minutes")
+    parser.add_argument("--short", type=int, default=5, help="Short break in minutes")
+    parser.add_argument("--long", type=int, default=15, help="Long break in minutes")
+    parser.add_argument("--cycles", type=int, default=4, help="Number of focus cycles")
+    parser.add_argument(
+        "--no-sound", action="store_true", help="Disable sound notifications"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    run_pomodoro(args.work, args.short, args.long, args.cycles, not args.no_sound)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
A lightweight, dependency-free command-line Pomodoro timer that lets you set custom focus, short break, and long break durations with configurable cycles. It shows a live countdown in the terminal and provides optional sound alerts, working on Windows, macOS, and Linux.